### PR TITLE
Remove duplicate implementations

### DIFF
--- a/Plugin/module_components/class.lua
+++ b/Plugin/module_components/class.lua
@@ -1,0 +1,29 @@
+local default_impl = function(instance, options)
+    return instance
+end
+
+return function(class_options)
+    local Class = {}
+    Class.__index = Class
+    --! Sugar code Class(Options) = Class:new(options)
+    local ClassMeta = {__call = function(class, options)
+        return class:new(options)
+    end}
+    setmetatable(Class, ClassMeta)
+    --! Wrapper for creating a table.
+    --! Sets the class table as a metatable.
+    --!  The equality 'getmetatable(instance) == class'
+    --! will necessarily be true.
+    --! Will call __init with the given options
+    function Class.new(class, options)
+        local instance = setmetatable({}, class)
+        return instance:__init(options)
+    end
+    class_options = class_options or {}
+    --! Sets init from the options.
+    --! If no init was given, it will use
+    --! UPVALUE - default_impl.
+    if class_options.init ~= nil then Class.__init = class_options.init else Class.__init = default_impl end
+
+    return Class
+end

--- a/Plugin/module_components/client_assets/client_class.lua
+++ b/Plugin/module_components/client_assets/client_class.lua
@@ -36,14 +36,4 @@
     self.player - reference to the client this script is running on
 --]]
 
-local MyClass = {}
-MyClass.__index = MyClass
-
-function MyClass:new(options)
-    -- construct object
-    local object = {}
-
-    return setmetatable(object, MyClass)
-end
-
-return MyClass
+return require(script.Parent.Parent.class)()

--- a/Plugin/module_components/server_assets/server_class.lua
+++ b/Plugin/module_components/server_assets/server_class.lua
@@ -34,14 +34,4 @@
     self:format_number(number)
 --]]
 
-local MyClass = {}
-MyClass.__index = MyClass
-
-function MyClass:new(options)
-    -- construct object
-    local object = {}
-
-    return setmetatable(object, MyClass)
-end
-
-return MyClass
+return require(script.Parent.Parent.class)()

--- a/Plugin/module_components/shared_assets/shared_class.lua
+++ b/Plugin/module_components/shared_assets/shared_class.lua
@@ -58,14 +58,4 @@
     self.player - reference to the client this script is running on
 --]]
 
-local MyClass = {}
-MyClass.__index = MyClass
-
-function MyClass:new(options)
-    -- construct object
-    local object = {}
-
-    return setmetatable(object, MyClass)
-end
-
-return MyClass
+return require(script.Parent.Parent.class)()


### PR DESCRIPTION
Move [server_assets.server_class](https://github.com/Jonesloto/Jonii-Express-Plugin/blob/main/Plugin/module_components/server_assets/server_class.lua) + [client_assets.client_class](https://github.com/Jonesloto/Jonii-Express-Plugin/blob/main/Plugin/module_components/client_assets/client_class.lua) + [shared_assets.shared_class](https://github.com/Jonesloto/Jonii-Express-Plugin/blob/main/Plugin/module_components/shared_assets/shared_class.lua) to [class](https://github.com/Jonesloto/Jonii-Express-Plugin/blob/main/Plugin/module_components/class.lua) 
Because code was repetitive (exactly the same).
<br> Modified class implementation to implement

1. Sugar code so that `class()` == `class:new()`
2. `__init` option function for object initialization